### PR TITLE
Updated installation guide for C18 revision.

### DIFF
--- a/src/installation.md
+++ b/src/installation.md
@@ -49,11 +49,23 @@ This should complete without any error. And you should be able to see a file nam
 ```bash
 annepro2_tools annepro2_c15_default.bin
 ```
-If you have the C18 revision, you will need to add `-p 8009` to the argument list
-in order to specify 0x8009 as the USB product ID. If this reports can't find device
-please double check you have the keyboard in IAP mode. We have found out some version
-of the bootloader only show one interface, which require the use of `--loosy` argument
-to use the first interface found on the device with `0x04d9:8009` vid pid pair.
+If you have the C18 revision, you must specify the interface number.
+```bash
+annepro2_tools annepro2_c18_default.bin -i=[[interface_number]]
+```
+Replace [[interface number]] with the keyboard's interface number. 
+
+If the tool reports can't find device please double check you have the keyboard in IAP mode.
+
+Interface number can be found by running the tool without the -i flag:
+```bash
+annepro2_tools annepro2_c18_default.bin
+```
+The tool lists the usb devices with their information. Search for the device with the `0x04d9:8009` vid pid pair:
+`HID Dev: 04d9:8009 if: [[interface_number]] Some("USB-HID IAP")`.
+This is the keyboard, interface number can be found here.
+
+If the tool doesn't list the keyboard please double check you have the keyboard in IAP mode.
 
 # Anne Pro 2 Shine
 
@@ -79,6 +91,6 @@ You will flash the .bin file using annepro2 tools
 ```bash
 annepro2_tools -t led build/annepro2-shine-C15.bin
 # for C18
-annepro2_tools -p 8009 -t led build/annepro2-shine-C18.bin
+annepro2_tools -t led -i=[[interface_number]] build/annepro2-shine-C18.bin
 
 Enjoy!


### PR DESCRIPTION
-p 8009 does't work anymore, interface number needs to be specified instead.